### PR TITLE
implement activate-based interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@ JavaConda is a Java wrapper for [Conda](https://docs.conda.io/en/latest/index.ht
 
 ## Getting started
 
+```java
+final Conda conda = new Conda( Paths.get(System.getProperty("user.home"), "miniconda").toString() );
+final String envName = "test";
+conda.create( envName ); // conda create -n envName
+conda.activate( envName ); // conda activate envName
+conda.install( "python=3.8" ); // conda install -y python=3.8
+conda.pipInstall( "cowsay" ); // pip install cowsay
+conda.runPython( "-c", "import cowsay; cowsay.cow('Hello World')" ); // python -c "import cowsay; cowsay.cow('Hello World')"
+```
+
 ### Create an instance of Conda class
 
-```
+```java
 final Conda conda = new Conda( Paths.get(System.getProperty("user.home"), "miniconda").toString() );
 ```
 
@@ -48,14 +58,32 @@ conda 4.10.3
 
 ```java
 final String envName = "test";
+conda.create( envName );
+```
+
+<details>
+<summary>additional info</summary>
+
+The command will throw an exception if the environment with the specified name already exists.\
+You can force overwriting it by adding the `isForceCreation` flag.
+
+```java
+conda.create( envName, true );
+```
+
+This is equivalent to the following code written in an explicit style.
+
+```java
 conda.runConda( "create", "-y", "-n", envName );
 ```
+
+</details>
 
 #### Create an environment from an environment file
 
 ```java
 final File envFile = new File( "path/to/environment.yml" );
-conda.runConda( "env", "create", "-f", envFile.getAbsolutePath() );
+conda.create( envName, "-f", envFile.getAbsolutePath() );
 ```
 
 <details>
@@ -74,22 +102,74 @@ variables:
 
 </details>
 
+<details>
+<summary>explicit style</summary>
+
+```java
+conda.runConda( "env", "create", "-n", envName, "-f", envFile.getAbsolutePath() );
+```
+
+</details>
+
+
+### Activate an environment
+
+```java
+conda.activate( envName );
+```
+
 ### Install Conda modules
+
+```java
+conda.install( "python=3.8" );
+```
+
+<details>
+<summary>without activation</summary>
+
+```java
+conda.install( envName, "python=3.8" );
+```
+
+</details>
+
+<details>
+<summary>explicit style</summary>
 
 ```java
 conda.runConda( "install", "-y", "-n", envName, "python=3.8" );
 ```
 
+</details>
+
 ### Install Pip moduels
+
+```java
+conda.pipInstall( "cowsay" );
+```
+
+<details>
+<summary>without activation</summary>
+
+```java
+conda.pipInstallIn( envName, "cowsay" );
+```
+
+</details>
+
+<details>
+<summary>explicit style</summary>
 
 ```java
 conda.runPython( envName, "-m", "pip", "install", "cowsay" );
 ```
 
+</details>
+
 ### List Conda environment names
 
 ```java
-final List< String > envs = conda.getEnvs();
+final List< String > envNames = conda.getEnvironmentNames();
 ```
 
 ### Run a Conda command
@@ -105,8 +185,18 @@ conda.runConda( "-h" );
  In Windows, this method also sets the `PATH` environment variable used by the specified environment.
 
 ```java
-conda.runPython( envName, "-c", "import cowsay; cowsay.cow('Hello World')" );
+conda.runPython( "-c", "import cowsay; cowsay.cow('Hello World')" );
 ```
+
+<details>
+<summary>without activation</summary>
+
+```java
+conda.runPythonIn( envName, "-c", "import cowsay; cowsay.cow('Hello World')" );
+```
+
+</details>
+
 
 <details>
 <summary>output</summary>
@@ -171,7 +261,7 @@ class User
 ```java
 final File pythonScript = new File( "output_json.py" );
 final Path jsonPath = Paths.get( "output.json" );
-conda.runPython( envName, pythonScript.getAbsolutePath(), jsonPath.toString() );
+conda.runPython( pythonScript.getAbsolutePath(), jsonPath.toString() );
 final Gson gson = new Gson();
 try (final Reader reader = Files.newBufferedReader( jsonPath ))
 {
@@ -191,9 +281,19 @@ User id: 0, User name: test
 ### Get environment variables associated with the specified environment
 
 ```java
-final Map< String, String > envvars = conda.getEnvironmentVariables( envName );
+conda.activate( envName );
+final Map< String, String > envvars = conda.getEnvironmentVariables();
 envvars.forEach( ( key, value ) -> System.out.println( key + ":" + value ) );
 ```
+
+<details>
+<summary>without activation</summary>
+
+```java
+final Map< String, String > envvars = conda.getEnvironmentVariables( envName );
+```
+
+</details>
 
 <details>
 <summary>output</summary>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.8.9</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-artifact</artifactId>
+			<version>3.8.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.javaconda</groupId>
 	<artifactId>javaconda</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 
 	<name>Javaconda</name>
 	<description>Java wrapper for Conda.</description>
@@ -48,7 +48,7 @@
 	<scm>
 		<connection>scm:git:git://github.com/javaconda/javaconda</connection>
 		<developerConnection>scm:git:git@github.com:javaconda/javaconda</developerConnection>
-		<tag>javaconda-0.2.0</tag>
+		<tag>HEAD</tag>
 		<url>https://github.com/javaconda/javaconda</url>
 	</scm>
 	<issueManagement>

--- a/src/main/java/org/javaconda/Conda.java
+++ b/src/main/java/org/javaconda/Conda.java
@@ -149,12 +149,14 @@ public class Conda
 					tempFile,
 					TIMEOUT_MILLIS,
 					TIMEOUT_MILLIS );
+			final List< String > cmd = getBaseCommand();
+
 			if ( SystemUtils.IS_OS_WINDOWS )
-				new ProcessBuilder().command( "cmd.exe", "/c", "start", "/wait", "\"\"", tempFile.getAbsolutePath(), "/InstallationType=JustMe", "/AddToPath=0", "/RegisterPython=0", "/S", "/D=" + rootdir )
-						.inheritIO().start().waitFor();
+				cmd.addAll( Arrays.asList( "start", "/wait", "\"\"", tempFile.getAbsolutePath(), "/InstallationType=JustMe", "/AddToPath=0", "/RegisterPython=0", "/S", "/D=" + rootdir ) );
 			else
-				new ProcessBuilder().command( "bash", tempFile.getAbsolutePath(), "-b", "-p", rootdir )
-						.inheritIO().start().waitFor();
+				cmd.addAll( Arrays.asList( "bash", tempFile.getAbsolutePath(), "-b", "-p", rootdir ) );
+			if ( new ProcessBuilder().inheritIO().command( cmd ).start().waitFor() != 0 )
+				throw new RuntimeException();
 		}
 		this.rootdir = rootdir;
 
@@ -162,7 +164,8 @@ public class Conda
 		// expected.
 		final List< String > cmd = getBaseCommand();
 		cmd.addAll( Arrays.asList( condaCommand, "-V" ) );
-		getBuilder( false ).command( cmd ).start().waitFor();
+		if ( getBuilder( false ).command( cmd ).start().waitFor() != 0 )
+			throw new RuntimeException();
 	}
 
 	/**
@@ -181,7 +184,8 @@ public class Conda
 		final List< String > cmd = getBaseCommand();
 		cmd.addAll( Arrays.asList( condaCommand, "-V" ) );
 		final Process process = getBuilder( false ).command( cmd ).start();
-		process.waitFor();
+		if ( process.waitFor() != 0 )
+			throw new RuntimeException();
 		return new BufferedReader( new InputStreamReader( process.getInputStream() ) ).readLine();
 	}
 
@@ -202,7 +206,8 @@ public class Conda
 		final List< String > cmd = getBaseCommand();
 		cmd.add( condaCommand );
 		cmd.addAll( Arrays.asList( args ) );
-		getBuilder( true ).command( cmd ).start().waitFor();
+		if ( getBuilder( true ).command( cmd ).start().waitFor() != 0 )
+			throw new RuntimeException();
 	}
 
 	/**
@@ -238,7 +243,8 @@ public class Conda
 			envs.put( "Path", Paths.get( envDir, "Library", "Bin" ).toString() + ";" + envs.get( "Path" ) );
 		}
 		builder.environment().putAll( getEnvironmentVariables( envName ) );
-		builder.command( cmd ).start().waitFor();
+		if ( builder.command( cmd ).start().waitFor() != 0 )
+			throw new RuntimeException();
 	}
 
 	/**
@@ -260,7 +266,8 @@ public class Conda
 		final List< String > cmd = getBaseCommand();
 		cmd.addAll( Arrays.asList( condaCommand, "env", "config", "vars", "list", "-n", envName ) );
 		final Process process = getBuilder( false ).command( cmd ).start();
-		process.waitFor();
+		if ( process.waitFor() != 0 )
+			throw new RuntimeException();
 		final Map< String, String > map = new HashMap<>();
 		try (final BufferedReader reader = new BufferedReader( new InputStreamReader( process.getInputStream() ) ))
 		{

--- a/src/main/java/org/javaconda/CondaException.java
+++ b/src/main/java/org/javaconda/CondaException.java
@@ -1,0 +1,96 @@
+package org.javaconda;
+
+public class CondaException
+{
+
+	public static class EnvironmentExistsException extends RuntimeException
+	{
+		private static final long serialVersionUID = -1625119813967214783L;
+
+		/**
+		 * Constructs a new exception with {@code null} as its detail message. The cause
+		 * is not initialized, and may subsequently be initialized by a call to
+		 * {@link #initCause}.
+		 */
+		public EnvironmentExistsException()
+		{
+			super();
+		}
+
+		/**
+		 * Constructs a new exception with the specified detail message. The cause is
+		 * not initialized, and may subsequently be initialized by a call to
+		 * {@link #initCause}.
+		 *
+		 * @param message
+		 *            the detail message. The detail message is saved for later
+		 *            retrieval by the {@link #getMessage()} method.
+		 */
+		public EnvironmentExistsException( String msg )
+		{
+			super( msg );
+		}
+
+		/**
+		 * Constructs a new exception with the specified detail message and cause.
+		 * <p>
+		 * Note that the detail message associated with {@code cause} is <i>not</i>
+		 * automatically incorporated in this exception's detail message.
+		 *
+		 * @param message
+		 *            the detail message (which is saved for later retrieval by the
+		 *            {@link #getMessage()} method).
+		 * @param cause
+		 *            the cause (which is saved for later retrieval by the
+		 *            {@link #getCause()} method). (A <tt>null</tt> value is permitted,
+		 *            and indicates that the cause is nonexistent or unknown.)
+		 * @since 1.4
+		 */
+		public EnvironmentExistsException( String message, Throwable cause )
+		{
+			super( message, cause );
+		}
+
+		/**
+		 * Constructs a new exception with the specified cause and a detail message of
+		 * <tt>(cause==null ? null : cause.toString())</tt> (which typically contains
+		 * the class and detail message of <tt>cause</tt>). This constructor is useful
+		 * for exceptions that are little more than wrappers for other throwables (for
+		 * example, {@link java.security.PrivilegedActionException}).
+		 *
+		 * @param cause
+		 *            the cause (which is saved for later retrieval by the
+		 *            {@link #getCause()} method). (A <tt>null</tt> value is permitted,
+		 *            and indicates that the cause is nonexistent or unknown.)
+		 * @since 1.4
+		 */
+		public EnvironmentExistsException( Throwable cause )
+		{
+			super( cause );
+		}
+
+		/**
+		 * Constructs a new exception with the specified detail message, cause,
+		 * suppression enabled or disabled, and writable stack trace enabled or
+		 * disabled.
+		 *
+		 * @param message
+		 *            the detail message.
+		 * @param cause
+		 *            the cause. (A {@code null} value is permitted, and indicates that
+		 *            the cause is nonexistent or unknown.)
+		 * @param enableSuppression
+		 *            whether or not suppression is enabled or disabled
+		 * @param writableStackTrace
+		 *            whether or not the stack trace should be writable
+		 * @since 1.7
+		 */
+		protected EnvironmentExistsException( String message, Throwable cause,
+				boolean enableSuppression,
+				boolean writableStackTrace )
+		{
+			super( message, cause, enableSuppression, writableStackTrace );
+		}
+	}
+
+}


### PR DESCRIPTION
## Updates

- implement activate-based interface
- wrappers for `conda install`, `conda update` and `pip install` are available
- rename `getEnvs()` to `getEnvironmentNames()`, which now returns "base" in addition to created environment names
- throw `RuntimeException` when the Python process exits with a non-zero code
- update README